### PR TITLE
Added base class methods for hardware power management

### DIFF
--- a/libraries/UHS_host/UHS_usbhost.h
+++ b/libraries/UHS_host/UHS_usbhost.h
@@ -36,7 +36,6 @@ e-mail   :  support@circuitsathome.com
 #define UHS_HOST_ERROR_JERR      0x0D // J-state instead of response
 #define UHS_HOST_ERROR_BADRQ     0x0A // Packet error. Increase max packet.
 #define UHS_HOST_ERROR_TIMEOUT   0x0E // Device did not respond in time
-#define UHS_HOST_ERROR_NOT_SUPPORTED   0x0D //Request not supported
 
 // Addressing error codes
 #define ADDR_ERROR_INVALID_INDEX                        0xA0
@@ -188,12 +187,12 @@ public:
 
         virtual uint8_t hwlPowerUp(void) {
                  /* This is for machine specific support to enable/power up the USB HW to operate*/
-                return UHS_HOST_ERROR_NOT_SUPPORTED;
+                return UHS_HOST_ERROR_NOT_IMPLEMENTED;
         };
 
         virtual uint8_t hwPowerDown(void) {
                 /* This is for machine specific support to disable/powerdown the USB Hw */
-                return UHS_HOST_ERROR_NOT_SUPPORTED;
+                return UHS_HOST_ERROR_NOT_IMPLEMENTED;
         };
 
         virtual bool IsHub(uint8_t klass) {

--- a/libraries/UHS_host/UHS_usbhost.h
+++ b/libraries/UHS_host/UHS_usbhost.h
@@ -36,6 +36,7 @@ e-mail   :  support@circuitsathome.com
 #define UHS_HOST_ERROR_JERR      0x0D // J-state instead of response
 #define UHS_HOST_ERROR_BADRQ     0x0A // Packet error. Increase max packet.
 #define UHS_HOST_ERROR_TIMEOUT   0x0E // Device did not respond in time
+#define UHS_HOST_ERROR_NOT_SUPPORTED   0x0D //Request not supported
 
 // Addressing error codes
 #define ADDR_ERROR_INVALID_INDEX                        0xA0
@@ -183,6 +184,16 @@ public:
 
         virtual int16_t UHS_NI Init(void) {
                 return Init(INT16_MIN);
+        };
+
+        virtual uint8_t hwlPowerUp(void) {
+                 /* This is for machine specific support to enable/power up the USB HW to operate*/
+                return UHS_HOST_ERROR_NOT_SUPPORTED;
+        };
+
+        virtual uint8_t hwPowerDown(void) {
+                /* This is for machine specific support to disable/powerdown the USB Hw */
+                return UHS_HOST_ERROR_NOT_SUPPORTED;
         };
 
         virtual bool IsHub(uint8_t klass) {


### PR DESCRIPTION
Class method that can be overriden to provide hardware power management.
It needs to be part of UHS_ISB_HOST_BASE and error in same name space?
Just checking but there appears to be a "uint8_t init(void)" and "uint16_t Init(void)"
