### PR TITLE
Option for the enumeration

### DIFF
--- a/libraries/UHS_host/UHS_CDC_ACM/examples/UHS_KINETIS_FS_HOST/acm_terminal/acm_terminal.ino
+++ b/libraries/UHS_host/UHS_CDC_ACM/examples/UHS_KINETIS_FS_HOST/acm_terminal/acm_terminal.ino
@@ -29,6 +29,8 @@
 // This needs testing.
 #define LOAD_UHS_CDC_ACM_FTDI
 
+//#define LOAD_UHS_ENUMERATION_OPT "UHS_host_INLINE_enumopt.h"
+
 #include <Arduino.h>
 #ifdef true
 #undef true

--- a/libraries/UHS_host/UHS_host_INLINE.h
+++ b/libraries/UHS_host/UHS_host_INLINE.h
@@ -198,6 +198,11 @@ uint8_t UHS_USB_HOST_BASE::doSoftReset(uint8_t parent, uint8_t port, uint8_t add
  *
  */
 
+#if defined(LOAD_UHS_ENUMERATION_OPT )
+
+#include LOAD_UHS_ENUMERATION_OPT
+
+#else
 /**
  * Enumerates interfaces on devices
  *
@@ -557,6 +562,7 @@ again:
         }
         return rcode;
 }
+#endif  //LOAD_UHS_ENUMERATION_OPT
 
 /**
  * Removes a device from the tables


### PR DESCRIPTION
Compiler option to allow for a separate user testable enumeration process.
User places LOAD_UHS_ENUMERATION_OPT in  .ino file
eg for example acm_terminal.ino 
#define LOAD_UHS_ENUMERATION_OPT "UHS_host_INLINE_enumopt.h"
and place the file specified by LOAD_UHS_ENUMERATION_OPT 
libraries/UHS_host/<LOAD_UHS_ENUMERATION_OPT>
User can then manage and test different enumeration sequences and merge them as needed.