### PR TITLE
Fix MIDI driver and update examples

### DIFF
--- a/libraries/UHS_host/UHS_MIDI/UHS_MIDI.h
+++ b/libraries/UHS_host/UHS_MIDI/UHS_MIDI.h
@@ -35,28 +35,27 @@ the GPL2 ("Copyleft").
 
 class UHS_MIDI : public UHS_USBInterface {
 protected:
+        volatile bool ready; // device ready indicator
+        uint8_t qPollRate; // How fast to poll maximum
+        uint16_t vid; //Vendor ID
+        uint16_t pid; //Product ID
+
+        /* MIDI Event packet buffer */
+        uint8_t *pktbuf;
+        UHS_ByteBuffer midibuf;
+
         uint16_t countSysExDataSize(uint8_t *dataptr);
-        uint8_t RecvData(uint16_t *bytes_rcvd, uint8_t *dataptr);
+        uint8_t _RecvData(uint16_t *bytes_rcvd, uint8_t *dataptr);
 
 public:
         static const uint8_t epDataInIndex = 1; // DataIn endpoint index(MIDI)
         static const uint8_t epDataOutIndex = 2; // DataOUT endpoint index(MIDI)
         volatile UHS_EpInfo epInfo[UHS_MIDI_MAX_ENDPOINTS];
-        volatile bool ready; // device ready indicator
-        uint8_t qPollRate; // How fast to poll maximum
-        uint16_t pid, vid;
-
-        /* MIDI Event packet buffer */
-        //uint8_t recvBuf[UHS_MIDI_EVENT_PACKET_SIZE];
-        //uint8_t readPtr;
-
-        uint8_t *pktbuf;
-
-        UHS_ByteBuffer midibuf;
 
         UHS_MIDI(UHS_USB_HOST_BASE *p);
 
         // Methods for receiving and sending data
+        uint8_t RecvData(uint16_t *bytes_rcvd, uint8_t *dataptr);
         uint8_t RecvData(uint8_t *outBuf, bool isRaw = false);
         uint8_t RecvRawData(uint8_t *outBuf);
         uint8_t SendData(uint8_t *dataptr, uint8_t nCable = 0);
@@ -64,6 +63,8 @@ public:
         uint8_t SendSysEx(uint8_t *dataptr, uint16_t datasize, uint8_t nCable = 0);
         uint8_t extractSysExData(uint8_t *p, uint8_t *buf);
         uint8_t SendRawData(uint16_t bytes_send, uint8_t *dataptr);
+        inline uint16_t idVendor() { return vid; }
+        inline uint16_t idProduct() { return pid; }
 
         uint8_t Start(void);
         bool OKtoEnumerate(ENUMERATION_INFO *ei);

--- a/libraries/UHS_host/UHS_MIDI/examples/UHS_KINETIS_FS_HOST/USB_MIDI_Converter/USB_MIDI_Converter.ino
+++ b/libraries/UHS_host/UHS_MIDI/examples/UHS_KINETIS_FS_HOST/USB_MIDI_Converter/USB_MIDI_Converter.ino
@@ -69,10 +69,6 @@ void MIDI_poll() {
 }
 
 void setup() {
-        // USB data switcher, PC -> device. (test jig, this can be ignored for regular use)
-        pinMode(5, OUTPUT);
-        digitalWriteFast(5, HIGH);
-
         // Activity LED. Lets us know we are alive.
         pinMode(LED_BUILTIN, OUTPUT);
         digitalWriteFast(LED_BUILTIN, HIGH);

--- a/libraries/UHS_host/UHS_MIDI/examples/UHS_KINETIS_FS_HOST/USB_MIDI_Converter/USB_MIDI_Converter.ino
+++ b/libraries/UHS_host/UHS_MIDI/examples/UHS_KINETIS_FS_HOST/USB_MIDI_Converter/USB_MIDI_Converter.ino
@@ -82,7 +82,7 @@ void setup() {
                 yield();
         }
         USB_HOST_SERIAL.begin(115200);
-        _MIDI_SERIAL_PORT.begin(230400);
+        _MIDI_SERIAL_PORT.begin(31250);
         UsbHost = new UHS_KINETIS_FS_HOST();
         Midi = new UHS_MIDI(UsbHost);
         while(UsbHost->Init(1000) != 0);

--- a/libraries/UHS_host/UHS_MIDI/examples/UHS_KINETIS_FS_HOST/USB_MIDI_dump/Makefile
+++ b/libraries/UHS_host/UHS_MIDI/examples/UHS_KINETIS_FS_HOST/USB_MIDI_dump/Makefile
@@ -1,0 +1,14 @@
+#BOARD=teensy:avr:teensy30:usb=disable,speed=96,opt=o1std,keys=en-us
+BOARD=teensy:avr:teensy31:usb=disable,speed=96,opt=o1std,keys=en-us
+#BOARD=teensy:avr:teensy33:usb=disable,speed=96,opt=o1std,keys=en-us
+#BOARD=teensy:avr:teensy34:usb=disable,speed=96,opt=o1std,keys=en-us
+#BOARD=teensy:avr:teensy35:usb=disable,speed=96,opt=o1std,keys=en-us
+#BOARD=teensy:avr:teensy36:usb=disable,speed=96,opt=o1std,keys=en-us
+
+PORT = /dev/ttyACM0
+CPORT = /dev/ttyUSB0
+
+# And finally, the part that brings everything together for you.
+HOMEDIR =$(HOME)
+BUILD_PATH ?=$(HOMEDIR)/Arduino/build/$(SKETCH)/_$(build_aDjOkT_core)/_$(build_aDjOkT_board)/_$(build_aDjOkT_arch)/_$(build_aDjOkT_mcu)
+include ~/Arduino/Arduino_Make/_Makefile.master

--- a/libraries/UHS_host/UHS_MIDI/examples/UHS_KINETIS_FS_HOST/USB_MIDI_dump/USB_MIDI_dump.ino
+++ b/libraries/UHS_host/UHS_MIDI/examples/UHS_KINETIS_FS_HOST/USB_MIDI_dump/USB_MIDI_dump.ino
@@ -9,15 +9,16 @@
  * This is sample program. Do not expect perfect behavior.
  *
  * Note: This driver is support for MIDI Streaming class only.
- *       If your MIDI Controler is not work, probably you needs its vendor specific driver. *******************************************************************************
+ *       If your MIDI Controler is not work, probably you needs its vendor specific driver. 
+ *******************************************************************************
  */
 
 // Patch printf so we can use it.
 #define LOAD_UHS_PRINTF_HELPER
 // Load the USB Host System core
 #define LOAD_USB_HOST_SYSTEM
-// Load USB Host Shield
-#define LOAD_USB_HOST_SHIELD
+// Load the Kinetis core
+#define LOAD_UHS_KINETIS_FS_HOST
 // Load MIDI class driver
 #define LOAD_UHS_MIDI
 
@@ -28,7 +29,7 @@
 //#define UHS_DEBUG_USB_ADDRESS 1
 // Redirect debugging and printf
 //#define UHS_DEVICE_WINDOWS_USB_SPEC_VIOLATION_DESCRIPTOR_DEVICE 1
-#define USB_HOST_SERIAL Serial
+#define USB_HOST_SERIAL Serial1
 
 #include <Arduino.h>
 #ifdef true
@@ -40,7 +41,7 @@
 
 #include <UHS_host.h>
 
-MAX3421E_HOST *UsbHost;
+UHS_KINETIS_FS_HOST *UsbHost;
 UHS_MIDI *Midi;
 bool connected;
 
@@ -49,7 +50,7 @@ void setup() {
   USB_HOST_SERIAL.begin(115200);
   delay(100);
 
-  UsbHost = new MAX3421E_HOST();
+  UsbHost = new UHS_KINETIS_FS_HOST();
   Midi = new UHS_MIDI(UsbHost);
 
   while (UsbHost->Init(1000) != 0);
@@ -62,7 +63,6 @@ void loop() {
       connected = true;
       printf_P(PSTR("Connected to MIDI\r\n"));
       printf_P(PSTR("VID:%04X, PID:%04X\r\n"), Midi->idVendor(), Midi->idProduct());
-
     }
     MIDI_poll();
   } else {

--- a/libraries/UHS_host/UHS_MIDI/examples/USB_HOST_SHIELD/USB_MIDI_Converter/USB_MIDI_Converter.ino
+++ b/libraries/UHS_host/UHS_MIDI/examples/USB_HOST_SHIELD/USB_MIDI_Converter/USB_MIDI_Converter.ino
@@ -84,7 +84,7 @@ void setup() {
         while(!USB_HOST_SERIAL) {
                 yield();
         }
-        _MIDI_SERIAL_PORT.begin(230400);
+        _MIDI_SERIAL_PORT.begin(31250);
         USB_HOST_SERIAL.begin(115200);
         delay(100);
         printf_P(PSTR("\r\n\r\n\r\n\r\n\r\n\r\nUSB MIDI Converter example.\r\n\r\n"));


### PR DESCRIPTION
Fix MIDI driver
- Remove redundant setConf()
- Add idVendor() and idProduct()
- Minor refactoring
- Update comments

Fix MIDI's examples
- Fix Serial MIDI speed
- Renew MIDI dump