### PR TITLE
Change license from "GPLv2" to "GPLv2 or later"

### DIFF
--- a/libraries/ISR_safe_memory/malloc.c
+++ b/libraries/ISR_safe_memory/malloc.c
@@ -6,12 +6,19 @@
    and
 Copyright (C) 2011 Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Contact information
 -------------------

--- a/libraries/ISR_safe_memory/mlock.c
+++ b/libraries/ISR_safe_memory/mlock.c
@@ -3,12 +3,19 @@
    and
 Copyright (C) 2011 Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Contact information
 -------------------

--- a/libraries/ISR_safe_memory/sectionname.h
+++ b/libraries/ISR_safe_memory/sectionname.h
@@ -3,12 +3,19 @@
    and
 Copyright (C) 2011 Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Contact information
 -------------------

--- a/libraries/ISR_safe_memory/stdlib_private.h
+++ b/libraries/ISR_safe_memory/stdlib_private.h
@@ -3,12 +3,19 @@
    and
 Copyright (C) 2011 Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Contact information
 -------------------

--- a/libraries/UHS_FS/PCpartition/PCPartition.cpp
+++ b/libraries/UHS_FS/PCpartition/PCPartition.cpp
@@ -2,12 +2,19 @@
    and
 Copyright (C) 2011 Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Contact information
 -------------------

--- a/libraries/UHS_FS/PCpartition/PCPartition.h
+++ b/libraries/UHS_FS/PCpartition/PCPartition.h
@@ -2,12 +2,19 @@
    and
 Copyright (C) 2011 Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Contact information
 -------------------

--- a/libraries/UHS_FS/UHS_FS.h
+++ b/libraries/UHS_FS/UHS_FS.h
@@ -9,12 +9,19 @@
    and
 Copyright (C) 2011 Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Contact information
 -------------------

--- a/libraries/UHS_FS/UHS_FS_INLINE.h
+++ b/libraries/UHS_FS/UHS_FS_INLINE.h
@@ -2,12 +2,19 @@
    and
 Copyright (C) 2011 Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Contact information
 -------------------

--- a/libraries/UHS_FS/fcntl.h
+++ b/libraries/UHS_FS/fcntl.h
@@ -9,12 +9,19 @@
    and
 Copyright (C) 2011 Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Contact information
 -------------------

--- a/libraries/UHS_host/UHS_ADK/UHS_ADK.h
+++ b/libraries/UHS_host/UHS_ADK/UHS_ADK.h
@@ -1,11 +1,18 @@
 /* Copyright (C) 2011 Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Contact information
 -------------------

--- a/libraries/UHS_host/UHS_ADK/UHS_ADK_INLINE.h
+++ b/libraries/UHS_host/UHS_ADK/UHS_ADK_INLINE.h
@@ -1,11 +1,18 @@
 /* Copyright (C) 2011 Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Contact information
 -------------------

--- a/libraries/UHS_host/UHS_BULK_STORAGE/UHS_BULK_STORAGE.h
+++ b/libraries/UHS_host/UHS_BULK_STORAGE/UHS_BULK_STORAGE.h
@@ -2,12 +2,19 @@
    and
  Copyright (C) 2011 Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Contact information
 -------------------

--- a/libraries/UHS_host/UHS_BULK_STORAGE/UHS_BULK_STORAGE_INLINE.h
+++ b/libraries/UHS_host/UHS_BULK_STORAGE/UHS_BULK_STORAGE_INLINE.h
@@ -2,12 +2,19 @@
    and
 Copyright (C) 2011 Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Contact information
 -------------------

--- a/libraries/UHS_host/UHS_BULK_STORAGE/UHS_SCSI.h
+++ b/libraries/UHS_host/UHS_BULK_STORAGE/UHS_SCSI.h
@@ -2,12 +2,19 @@
    and
 Copyright (C) 2011 Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Contact information
 -------------------

--- a/libraries/UHS_host/UHS_CDC/UHS_CDC.h
+++ b/libraries/UHS_host/UHS_CDC/UHS_CDC.h
@@ -2,12 +2,19 @@
    and
 Copyright (C) 2011 Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Contact information
 -------------------

--- a/libraries/UHS_host/UHS_CDC_ACM/UHS_CDC_ACM.h
+++ b/libraries/UHS_host/UHS_CDC_ACM/UHS_CDC_ACM.h
@@ -2,12 +2,19 @@
    and
 Copyright (C) 2011 Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Contact information
 -------------------

--- a/libraries/UHS_host/UHS_CDC_ACM/UHS_CDC_ACM_FTDI.h
+++ b/libraries/UHS_host/UHS_CDC_ACM/UHS_CDC_ACM_FTDI.h
@@ -2,12 +2,19 @@
    and
 Copyright (C) 2011 Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Contact information
 -------------------

--- a/libraries/UHS_host/UHS_CDC_ACM/UHS_CDC_ACM_INLINE.h
+++ b/libraries/UHS_host/UHS_CDC_ACM/UHS_CDC_ACM_INLINE.h
@@ -2,13 +2,19 @@
    and
 Copyright (C) 2011 Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
 
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 Contact information
 -------------------
 

--- a/libraries/UHS_host/UHS_CDC_ACM/UHS_CDC_ACM_PROLIFIC.h
+++ b/libraries/UHS_host/UHS_CDC_ACM/UHS_CDC_ACM_PROLIFIC.h
@@ -2,12 +2,19 @@
    and
 Copyright (C) 2011 Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Contact information
 -------------------

--- a/libraries/UHS_host/UHS_CDC_ACM/UHS_CDC_ACM_XR21B1411.h
+++ b/libraries/UHS_host/UHS_CDC_ACM/UHS_CDC_ACM_XR21B1411.h
@@ -2,12 +2,19 @@
    and
    Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Contact information
 -------------------

--- a/libraries/UHS_host/UHS_HID/HIDBOOT/UHS_HIDRAWBOOT_KEYBOARD.h
+++ b/libraries/UHS_host/UHS_HID/HIDBOOT/UHS_HIDRAWBOOT_KEYBOARD.h
@@ -2,12 +2,19 @@
    and
 Copyright (C) 2011 Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Contact information
 -------------------
@@ -29,12 +36,12 @@ e-mail   :  support@circuitsathome.com
 
 #if DEBUG_PRINTF_EXTRA_HUGE
 #if DEBUG_PRINTF_EXTRA_HUGE_USB_HIDBOOT_KEYBOARD
-#define HIDBOOT_KEYBOARD_DUBUG(...) printf(__VA_ARGS__)
+#define HIDBOOT_KEYBOARD_DEBUG(...) printf(__VA_ARGS__)
 #else
-#define HID_DUBUGBOOT_KEYBOARD(...) VOID0
+#define HID_DEBUGBOOT_KEYBOARD(...) VOID0
 #endif
 #else
-#define HID_DUBUGBOOT_KEYBOARD(...) VOID0
+#define HID_DEBUGBOOT_KEYBOARD(...) VOID0
 #endif
 
 class UHS_HIDBOOT_keyboard : public UHS_HID_base {
@@ -59,7 +66,7 @@ public:
                 if(rv == 0) {
                         parent->hidProcessor->onPoll(this, data, length);
                 } else if(rv != UHS_HOST_ERROR_NAK) {
-                        HID_DUBUGBOOT_KEYBOARD("DP %02x A %02x EI %02x EA %02x\r\n", rv, parent->bAddress, parent->epInterruptInIndex, parent->epInfo[parent->epInterruptInIndex].epAddr);
+                        HID_DEBUGBOOT_KEYBOARD("DP %02x A %02x EI %02x EA %02x\r\n", rv, parent->bAddress, parent->epInterruptInIndex, parent->epInfo[parent->epInterruptInIndex].epAddr);
                 }
         }
 

--- a/libraries/UHS_host/UHS_HID/HIDBOOT/UHS_HIDRAWBOOT_MOUSE.h
+++ b/libraries/UHS_host/UHS_HID/HIDBOOT/UHS_HIDRAWBOOT_MOUSE.h
@@ -2,12 +2,19 @@
    and
 Copyright (C) 2011 Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Contact information
 -------------------
@@ -29,12 +36,12 @@ e-mail   :  support@circuitsathome.com
 
 #if DEBUG_PRINTF_EXTRA_HUGE
 #if DEBUG_PRINTF_EXTRA_HUGE_USB_HIDBOOT_MOUSE
-#define HIDBOOT_MOUSE_DUBUG(...) printf(__VA_ARGS__)
+#define HIDBOOT_MOUSE_DEBUG(...) printf(__VA_ARGS__)
 #else
-#define HIDBOOT_MOUSE_DUBUG(...) VOID0
+#define HIDBOOT_MOUSE_DEBUG(...) VOID0
 #endif
 #else
-#define HIDBOOT_MOUSE_DUBUG(...) VOID0
+#define HIDBOOT_MOUSE_DEBUG(...) VOID0
 #endif
 
 struct MOUSEINFO {
@@ -75,7 +82,7 @@ public:
                                 parent->hidProcessor->onPoll(this, data, length);
                         }
                 } else if(rv != UHS_HOST_ERROR_NAK) {
-                        HIDBOOT_MOUSE_DUBUG("DP %02x A %02x EI %02x EA %02x\r\n", rv, parent->bAddress, parent->epInterruptInIndex, parent->epInfo[parent->epInterruptInIndex].epAddr);
+                        HIDBOOT_MOUSE_DEBUG("DP %02x A %02x EI %02x EA %02x\r\n", rv, parent->bAddress, parent->epInterruptInIndex, parent->epInfo[parent->epInterruptInIndex].epAddr);
                 }
         }
 

--- a/libraries/UHS_host/UHS_HID/UHS_HID.h
+++ b/libraries/UHS_host/UHS_HID/UHS_HID.h
@@ -2,12 +2,19 @@
    and
 Copyright (C) 2011 Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Contact information
 -------------------
@@ -27,12 +34,12 @@ e-mail   :  support@circuitsathome.com
 #endif
 #if DEBUG_PRINTF_EXTRA_HUGE
 #if DEBUG_PRINTF_EXTRA_HUGE_USB_HID
-#define HID_DUBUG(...) printf(__VA_ARGS__)
+#define HID_DEBUG(...) printf(__VA_ARGS__)
 #else
-#define HID_DUBUG(...) VOID0
+#define HID_DEBUG(...) VOID0
 #endif
 #else
-#define HID_DUBUG(...) VOID0
+#define HID_DEBUG(...) VOID0
 #endif
 
 #ifndef AJK_NI

--- a/libraries/UHS_host/UHS_HID/UHS_HID_INLINE.h
+++ b/libraries/UHS_host/UHS_HID/UHS_HID_INLINE.h
@@ -2,12 +2,19 @@
    and
 Copyright (C) 2011 Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Contact information
 -------------------
@@ -22,12 +29,12 @@ e-mail   :  support@circuitsathome.com
 
 #if DEBUG_PRINTF_EXTRA_HUGE
 #if DEBUG_PRINTF_EXTRA_HUGE_USB_HID
-#define HID_DUBUG(...) printf(__VA_ARGS__)
+#define HID_DEBUG(...) printf(__VA_ARGS__)
 #else
-#define HID_DUBUG(...) VOID0
+#define HID_DEBUG(...) VOID0
 #endif
 #else
-#define HID_DUBUG(...) VOID0
+#define HID_DEBUG(...) VOID0
 #endif
 
 #ifndef AJK_NI
@@ -123,7 +130,7 @@ uint8_t UHS_NI UHS_HID::SetReport(uint8_t iface, uint8_t report_type, uint8_t re
 }
 
 uint8_t UHS_NI UHS_HID::Start(void) {
-        HID_DUBUG("HID START, A %02x I %02x O %02x\r\n", bAddress, epInfo[epInterruptInIndex].epAddr, epInfo[epInterruptOutIndex].epAddr);
+        HID_DEBUG("HID START, A %02x I %02x O %02x\r\n", bAddress, epInfo[epInterruptInIndex].epAddr, epInfo[epInterruptOutIndex].epAddr);
         uint8_t rcode = pUsb->setEpInfoEntry(bAddress, bIface, 3, epInfo);
         if(rcode) {
                 Release();

--- a/libraries/UHS_host/UHS_HUB/UHS_HUB.h
+++ b/libraries/UHS_host/UHS_HUB/UHS_HUB.h
@@ -2,12 +2,19 @@
    and
 Copyright (C) 2011 Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Contact information
 -------------------

--- a/libraries/UHS_host/UHS_HUB/UHS_HUB_INLINE.h
+++ b/libraries/UHS_host/UHS_HUB/UHS_HUB_INLINE.h
@@ -2,12 +2,19 @@
    and
 Copyright (C) 2011 Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Contact information
 -------------------
@@ -22,12 +29,12 @@ e-mail   :  support@circuitsathome.com
 
 #if DEBUG_PRINTF_EXTRA_HUGE
 #ifdef DEBUG_PRINTF_EXTRA_HUGE_USB_HUB
-#define HUB_DUBUG(...) printf(__VA_ARGS__)
+#define HUB_DEBUG(...) printf(__VA_ARGS__)
 #else
-#define HUB_DUBUG(...) VOID0
+#define HUB_DEBUG(...) VOID0
 #endif
 #else
-#define HUB_DUBUG(...) VOID0
+#define HUB_DEBUG(...) VOID0
 #endif
 
 
@@ -43,7 +50,7 @@ UHS_NI UHS_USBHub::UHS_USBHub(UHS_USB_HOST_BASE *p) {
 }
 
 bool UHS_NI UHS_USBHub::OKtoEnumerate(ENUMERATION_INFO *ei) {
-        HUB_DUBUG("USBHub: checking numep %i, klass %2.2x, interface.klass %2.2x\r\n", ei->interface.numep, ei->klass, ei->interface.klass);
+        HUB_DEBUG("USBHub: checking numep %i, klass %2.2x, interface.klass %2.2x\r\n", ei->interface.numep, ei->klass, ei->interface.klass);
         return ((ei->interface.numep == 1) && ((ei->klass == UHS_USB_CLASS_HUB) || (ei->interface.klass == UHS_USB_CLASS_HUB)));
 }
 
@@ -62,7 +69,7 @@ void UHS_NI UHS_USBHub::DriverDefaults(void) {
 
 uint8_t UHS_NI UHS_USBHub::SetInterface(ENUMERATION_INFO *ei) {
         //DriverDefaults();
-        HUB_DUBUG("USBHub Accepting address assignment %2.2x\r\n", ei->address);
+        HUB_DEBUG("USBHub Accepting address assignment %2.2x\r\n", ei->address);
         bNumEP = 2;
         bAddress = ei->address;
         epInfo[0].epAddr = 0;
@@ -149,7 +156,7 @@ void UHS_NI UHS_USBHub::CheckHubStatus(void) {
         rcode = pUsb->inTransfer(bAddress, 1, &read, buf);
 
         if(rcode) {
-                HUB_DUBUG("UHS_USBHub::CheckHubStatus %2.2x\r\n", rcode);
+                HUB_DEBUG("UHS_USBHub::CheckHubStatus %2.2x\r\n", rcode);
                 return;
         }
 
@@ -262,7 +269,7 @@ uint8_t UHS_NI UHS_USBHub::PortStatusChange(uint8_t port, UHS_HubEvent &evt) {
                                 UHS_SLEEP_MS(200);
 
                                 a.devAddress = bAddress;
-                                HUB_DUBUG("USBHub configure %2.2x %2.2x %2.2x\r\n", a.bmAddress, port, ((evt.bmStatus & UHS_HUB_bmPORT_STATUS_PORT_LOW_SPEED)==UHS_HUB_bmPORT_STATUS_PORT_LOW_SPEED?0:1));
+                                HUB_DEBUG("USBHub configure %2.2x %2.2x %2.2x\r\n", a.bmAddress, port, ((evt.bmStatus & UHS_HUB_bmPORT_STATUS_PORT_LOW_SPEED)==UHS_HUB_bmPORT_STATUS_PORT_LOW_SPEED?0:1));
                                 pUsb->Configuring(a.bmAddress, port, ((evt.bmStatus & UHS_HUB_bmPORT_STATUS_PORT_LOW_SPEED)==UHS_HUB_bmPORT_STATUS_PORT_LOW_SPEED?0:1));
                                 bResetInitiated = false;
                         }

--- a/libraries/UHS_host/UHS_KINETIS_FS_HOST/UHS_KINETIS_FS_HOST.h
+++ b/libraries/UHS_host/UHS_KINETIS_FS_HOST/UHS_KINETIS_FS_HOST.h
@@ -2,12 +2,19 @@
    and
 Copyright (C) 2011 Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Contact information
 -------------------

--- a/libraries/UHS_host/UHS_KINETIS_FS_HOST/UHS_KINETIS_FS_HOST_INLINE.h
+++ b/libraries/UHS_host/UHS_KINETIS_FS_HOST/UHS_KINETIS_FS_HOST_INLINE.h
@@ -2,12 +2,19 @@
    and
 Copyright (C) 2011 Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Contact information
 -------------------
@@ -43,14 +50,14 @@ void UHS_NI UHS_KINETIS_FS_HOST::busprobe(void) {
         //printf("\r\nUSB0_CTL: %x \r\n", USB0_CTL);
         //printf("\r\nbus_sample: %x \r\n", bus_sample);
 
-        HOST_DUBUG("bus_sample: %x ", bus_sample);
+        HOST_DEBUG("bus_sample: %x ", bus_sample);
         // 0xC0 disconnected
         // 0x80 low speed
         // 0x40 disconnected
         // 0x00 full speed
         switch(bus_sample) { //start full-speed or low-speed host
                 case(UHS_KINETIS_FS_bmJSTATUS): // full speed
-                        HOST_DUBUG("full speed\r\n");
+                        HOST_DEBUG("full speed\r\n");
                         USB0_OTGCTL &= ~(USB_OTGCTL_DPLOW | USB_OTGCTL_DMLOW); // disable D+ and D- pulldowns
                         USB0_INTEN &= ~USB_INTEN_ATTACHEN;
                         USB0_ADDR = 0;
@@ -62,7 +69,7 @@ void UHS_NI UHS_KINETIS_FS_HOST::busprobe(void) {
                         vbusState = UHS_KINETIS_FS_FSHOST;
                         break;
                 case(UHS_KINETIS_FS_bmKSTATUS): // low speed
-                        HOST_DUBUG("low speed\r\n");
+                        HOST_DEBUG("low speed\r\n");
                         USB0_OTGCTL &= ~(USB_OTGCTL_DPLOW | USB_OTGCTL_DMLOW); // disable D+ and D- pulldowns
                         USB0_INTEN &= ~USB_INTEN_ATTACHEN;
                         USB0_ADDR = USB_ADDR_LSEN; // low speed enable, address 0
@@ -73,7 +80,7 @@ void UHS_NI UHS_KINETIS_FS_HOST::busprobe(void) {
                         vbusState = UHS_KINETIS_FS_LSHOST;
                         break;
                 case(UHS_KINETIS_FS_bmSE0): //disconnected state
-                        HOST_DUBUG("disconnected\r\n");
+                        HOST_DEBUG("disconnected\r\n");
                         vbusState = UHS_KINETIS_FS_SE0;
                         USB0_OTGCTL = USB_OTGCTL_DPLOW | USB_OTGCTL_DMLOW; // enable D+ and D- pulldowns
                         USB0_ADDR = 0;
@@ -81,7 +88,7 @@ void UHS_NI UHS_KINETIS_FS_HOST::busprobe(void) {
                         USB0_INTEN |= USB_INTEN_ATTACHEN;
                         break;
                 case(UHS_KINETIS_FS_bmSE1): // second disconnected state
-                        HOST_DUBUG("disconnected2\r\n");
+                        HOST_DEBUG("disconnected2\r\n");
                         vbusState = UHS_KINETIS_FS_SE1;
                         USB0_OTGCTL = USB_OTGCTL_DPLOW | USB_OTGCTL_DMLOW; // enable D+ and D- pulldowns
                         USB0_ADDR = 0;
@@ -181,7 +188,7 @@ void UHS_NI UHS_KINETIS_FS_HOST::ISRbottom(void) {
                         break; // don't fall through
 
                 case UHS_USB_HOST_STATE_CONFIGURING:
-                        HOST_DUBUG("ISRbottom, UHS_USB_HOST_STATE_CONFIGURING\r\n");
+                        HOST_DEBUG("ISRbottom, UHS_USB_HOST_STATE_CONFIGURING\r\n");
                         usb_task_state = UHS_USB_HOST_STATE_CHECK;
                         x = Configuring(0, 1, usb_host_speed);
                         if(usb_task_state == UHS_USB_HOST_STATE_CHECK) {
@@ -197,7 +204,7 @@ void UHS_NI UHS_KINETIS_FS_HOST::ISRbottom(void) {
                         }
                         break;
                 case UHS_USB_HOST_STATE_CONFIGURING_DONE:
-                        HOST_DUBUG("ISRbottom, UHS_USB_HOST_STATE_CONFIGURING_DONE\r\n");
+                        HOST_DEBUG("ISRbottom, UHS_USB_HOST_STATE_CONFIGURING_DONE\r\n");
                         usb_task_state = UHS_USB_HOST_STATE_RUNNING;
                         break;
                 case UHS_USB_HOST_STATE_CHECK:
@@ -339,12 +346,12 @@ void UHS_NI UHS_KINETIS_FS_HOST::ISRTask(void) {
 #if DEBUG_PRINTF_EXTRA_HUGE_UHS_HOST
                 uint8_t count = b_newToken.desc >> 16;
                 uint8_t *buf = (uint8_t *)b_newToken.addr;
-                HOST_DUBUG("ISR: TOKDNE. Pid: %lx", pid);
-                HOST_DUBUG(", count: %x", count);
+                HOST_DEBUG("ISR: TOKDNE. Pid: %lx", pid);
+                HOST_DEBUG(", count: %x", count);
                 if(count) {
-                        HOST_DUBUG(". Data: %lx", *(uint32_t *)(buf));
+                        HOST_DEBUG(". Data: %lx", *(uint32_t *)(buf));
                 }
-                HOST_DUBUG("\r\n");
+                HOST_DEBUG("\r\n");
 
 #endif
                 HW_CLEAR |= USB_ISTAT_TOKDNE;
@@ -352,14 +359,14 @@ void UHS_NI UHS_KINETIS_FS_HOST::ISRTask(void) {
         }
 
         if(status & USB_ISTAT_USBRST) { // bus reset
-                HOST_DUBUG("ISR: reset\r\n");
+                HOST_DEBUG("ISR: reset\r\n");
                 condet = true; // ALWAYS
                 busprobe();
                 HW_CLEAR |= USB_ISTAT_USBRST;
         }
 
         if((status & USB_ISTAT_ATTACH)) { // device attached to the usb
-                HOST_DUBUG("ISR: Attach\r\n");
+                HOST_DEBUG("ISR: Attach\r\n");
                 condet = true;
                 busprobe();
                 HW_CLEAR |= USB_ISTAT_ATTACH;
@@ -379,13 +386,13 @@ void UHS_NI UHS_KINETIS_FS_HOST::ISRTask(void) {
 
 #if 0
         if((status & USB_ISTAT_SLEEP)) { // sleep
-                HOST_DUBUG("ISR: sleep\r\n");
+                HOST_DEBUG("ISR: sleep\r\n");
                 // serial_print("sleep\n");
                 HW_CLEAR |= USB_ISTAT_SLEEP;
         }
 
         if((status & USB_ISTAT_RESUME)) { // resume
-                HOST_DUBUG("ISR: resume\r\n");
+                HOST_DEBUG("ISR: resume\r\n");
                 // serial_print("resume\n");
                 HW_CLEAR |= USB_ISTAT_RESUME;
         }
@@ -449,7 +456,7 @@ uint8_t UHS_NI UHS_KINETIS_FS_HOST::SetAddress(uint8_t addr, uint8_t ep, UHS_EpI
         //USBTRACE2(" RETRY DISABLE: ", ((nak_limit > 2U) ? 0 : 1));
         //USBTRACE("\r\n");
 
-        //HOST_DUBUG("\r\nAddress: %2.2x. EP: %2.2x, NAK Power: %2.2x, NAK Limit: %u\r\n", addr, ep, (*ppep)->bmNakPower, nak_limit);
+        //HOST_DEBUG("\r\nAddress: %2.2x. EP: %2.2x, NAK Power: %2.2x, NAK Limit: %u\r\n", addr, ep, (*ppep)->bmNakPower, nak_limit);
         // address and low speed enable
         USB0_ADDR = addr | ((p->speed) ? 0 : USB_ADDR_LSEN);
 
@@ -499,7 +506,7 @@ uint8_t UHS_NI UHS_KINETIS_FS_HOST::dispatchPkt(uint8_t token, uint8_t ep, uint1
         // Better would be to find how many TT's are on the hub, though...
         uint8_t rcode;
 
-        //HOST_DUBUG("dispatchPkt: token %x, ep: %i, nak_limit: %i \r\n", token, ep, nak_limit);
+        //HOST_DEBUG("dispatchPkt: token %x, ep: %i, nak_limit: %i \r\n", token, ep, nak_limit);
 
         rcode = UHS_HOST_ERROR_TIMEOUT;
         newError = false;
@@ -592,7 +599,7 @@ uint8_t UHS_NI UHS_KINETIS_FS_HOST::OutTransfer(UHS_EpInfo *pep, uint16_t nak_li
         ep0_tx_data_toggle = pep->bmSndToggle;
 
         while(bytes_left && !rcode) {
-                HOST_DUBUG(", maxpktsize: %i, bytes_left: %i\r\n", maxpktsize, bytes_left);
+                HOST_DEBUG(", maxpktsize: %i, bytes_left: %i\r\n", maxpktsize, bytes_left);
 
                 bytes_tosend = (bytes_left >= maxpktsize) ? maxpktsize : bytes_left;
                 endpoint0_transmit(p_buffer, bytes_tosend); // setup internal buffer
@@ -646,12 +653,12 @@ uint8_t UHS_NI UHS_KINETIS_FS_HOST::InTransfer(UHS_EpInfo *pep, uint16_t nak_lim
                 if(datalen + *nbytesptr > nbytes) { // get less than maxpktsize if we don't need a full maxpktsize
                         datalen = nbytes - *nbytesptr;
                 }
-                HOST_DUBUG("datalen: %lu \r\n", datalen);
+                HOST_DEBUG("datalen: %lu \r\n", datalen);
                 endpoint0_receive(data_in_buf, datalen); // setup internal buffer
                 rcode = dispatchPkt(UHS_KINETIS_FS_TOKEN_DATA_IN, ep, nak_limit); //dispatch packet
                 //digitalWriteFast(2, LOW);
                 pktsize = b_newToken.desc >> 16; // how many bytes we actually got
-                HOST_DUBUG("pktsize: %i \r\n", pktsize);
+                HOST_DEBUG("pktsize: %i \r\n", pktsize);
                 if(rcode == UHS_HOST_ERROR_MEM_LAT) {
                         // something we need to do here, but what?
                         // datasheet isn't clear, just says that these are transient
@@ -667,17 +674,17 @@ uint8_t UHS_NI UHS_KINETIS_FS_HOST::InTransfer(UHS_EpInfo *pep, uint16_t nak_lim
                         //        *nbytesptr += pktsize; // add to the number of bytes read
                         //        break;
                         //}
-                        //HOST_DUBUG(">>>>hrUNDEF>>>> InTransfer Problem! dispatchPkt ", rcode);
+                        //HOST_DEBUG(">>>>hrUNDEF>>>> InTransfer Problem! dispatchPkt ", rcode);
                         break; //should be 0, indicating ACK. Else return error code.
                 }
 
 #if ENABLE_UHS_DEBUGGING
                 uint8_t i = 0;
-                HOST_DUBUG("-----Data packet: ");
+                HOST_DEBUG("-----Data packet: ");
                 for(i = 0; i < pktsize; i++) {
-                        HOST_DUBUG("%02x ", data_in_buf[i]);
+                        HOST_DEBUG("%02x ", data_in_buf[i]);
                 }
-                HOST_DUBUG("\r\n");
+                HOST_DEBUG("\r\n");
 #endif
                 if(pktsize + *nbytesptr > nbytes) { // adjust pktsize if we don't need all the bytes we just got
                         pktsize = nbytes - *nbytesptr;
@@ -720,7 +727,7 @@ UHS_EpInfo * UHS_NI UHS_KINETIS_FS_HOST::ctrlReqOpen(uint8_t addr, uint64_t Requ
 
         UHS_EpInfo *pep = NULL;
         uint16_t nak_limit = 0;
-        //HOST_DUBUG("ctrlReqOpen: addr: 0x%2.2x bmReqType: 0x%2.2x bRequest: 0x%2.2x\r\nctrlReqOpen: wValLo: 0x%2.2x  wValHi: 0x%2.2x wInd: 0x%4.4x total: 0x%4.4x dataptr: %p\r\n", addr, bmReqType, bRequest, wValLo, wValHi, wInd, total, dataptr);
+        //HOST_DEBUG("ctrlReqOpen: addr: 0x%2.2x bmReqType: 0x%2.2x bRequest: 0x%2.2x\r\nctrlReqOpen: wValLo: 0x%2.2x  wValHi: 0x%2.2x wInd: 0x%4.4x total: 0x%4.4x dataptr: %p\r\n", addr, bmReqType, bRequest, wValLo, wValHi, wInd, total, dataptr);
         rcode = SetAddress(addr, 0, &pep, nak_limit);
 
         if(!rcode) {
@@ -771,16 +778,16 @@ uint8_t UHS_NI UHS_KINETIS_FS_HOST::ctrlReqRead(UHS_EpInfo *pep, uint16_t *left,
         *read = 0;
         uint8_t rcode = 0;
         uint16_t nak_limit = 0;
-        HOST_DUBUG("ctrlReqRead left: %i\r\n", *left);
+        HOST_DEBUG("ctrlReqRead left: %i\r\n", *left);
         if(*left) {
                 *read = nbytes;
                 rcode = InTransfer(pep, nak_limit, read, dataptr);
 
                 if(rcode) {
-                        HOST_DUBUG("ctrlReqRead ERROR: %2.2x, left: %i, read %i\r\n", rcode, *left, *read);
+                        HOST_DEBUG("ctrlReqRead ERROR: %2.2x, left: %i, read %i\r\n", rcode, *left, *read);
                 } else {
                         *left -= *read;
-                        HOST_DUBUG("ctrlReqRead left: %i, read %i\r\n", *left, *read);
+                        HOST_DEBUG("ctrlReqRead left: %i, read %i\r\n", *left, *read);
                 }
         }
         return rcode;
@@ -799,11 +806,11 @@ uint8_t UHS_NI UHS_KINETIS_FS_HOST::ctrlReqRead(UHS_EpInfo *pep, uint16_t *left,
 uint8_t UHS_NI UHS_KINETIS_FS_HOST::ctrlReqClose(UHS_EpInfo *pep, uint8_t bmReqType, uint16_t left, uint16_t nbytes, uint8_t * dataptr) {
         uint8_t rcode = 0;
 
-        //HOST_DUBUG("Inside ctrlReqClose. bmReqType: %x, left: %x, nbytes: %x \r\n", bmReqType, left, nbytes);
+        //HOST_DEBUG("Inside ctrlReqClose. bmReqType: %x, left: %x, nbytes: %x \r\n", bmReqType, left, nbytes);
 
         if(((bmReqType & 0x80) == 0x80) && pep && left && dataptr) {
                 //Serial.println("Drain");
-                HOST_DUBUG("ctrlReqClose Sinking %i\r\n", left);
+                HOST_DEBUG("ctrlReqClose Sinking %i\r\n", left);
                 // If reading, sink the rest of the data.
                 while(left) {
                         uint16_t read = nbytes;
@@ -987,11 +994,11 @@ void UHS_NI UHS_KINETIS_FS_HOST::endpoint0_transmit(const void *data, uint32_t l
         if(len > 0) {
                 uint32_t i = 0;
                 uint8_t *real_data = (uint8_t *)data;
-                HOST_DUBUG("tx0: ");
+                HOST_DEBUG("tx0: ");
                 for(i = 0; i < len; i++) {
-                        HOST_DUBUG("%x ", *(real_data + i));
+                        HOST_DEBUG("%x ", *(real_data + i));
                 }
-                HOST_DUBUG(", %lx\r\n", len);
+                HOST_DEBUG(", %lx\r\n", len);
         }
 #endif
         last_count = len;
@@ -1007,7 +1014,7 @@ void UHS_NI UHS_KINETIS_FS_HOST::endpoint0_transmit(const void *data, uint32_t l
 void UHS_NI UHS_KINETIS_FS_HOST::endpoint0_receive(const void *data, uint32_t len) {
         //#if ENABLE_UHS_DEBUGGING
 #if 1
-        HOST_DUBUG("endpoint0_receive: %lx", len);
+        HOST_DEBUG("endpoint0_receive: %lx", len);
 #endif
 
         last_count = len;

--- a/libraries/UHS_host/UHS_UNOFFICIAL_IDs.h
+++ b/libraries/UHS_host/UHS_UNOFFICIAL_IDs.h
@@ -2,12 +2,19 @@
    and
 Copyright (C) 2011 Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Contact information
 -------------------

--- a/libraries/UHS_host/UHS_UsbCore.h
+++ b/libraries/UHS_host/UHS_UsbCore.h
@@ -2,12 +2,19 @@
    and
 Copyright (C) 2011 Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Contact information
 -------------------

--- a/libraries/UHS_host/UHS_address.h
+++ b/libraries/UHS_host/UHS_address.h
@@ -2,12 +2,19 @@
    and
 Copyright (C) 2011 Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Contact information
 -------------------

--- a/libraries/UHS_host/UHS_hexdump.h
+++ b/libraries/UHS_host/UHS_hexdump.h
@@ -2,12 +2,19 @@
    and
 Copyright (C) 2011 Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Contact information
 -------------------

--- a/libraries/UHS_host/UHS_host.h
+++ b/libraries/UHS_host/UHS_host.h
@@ -2,12 +2,19 @@
    and
 Copyright (C) 2011 Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Contact information
 -------------------

--- a/libraries/UHS_host/UHS_host_INLINE.h
+++ b/libraries/UHS_host/UHS_host_INLINE.h
@@ -2,12 +2,19 @@
    and
 Copyright (C) 2011 Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Contact information
 -------------------
@@ -26,12 +33,12 @@ e-mail   :  support@circuitsathome.com
 
 #if DEBUG_PRINTF_EXTRA_HUGE
 #if DEBUG_PRINTF_EXTRA_HUGE_UHS_HOST
-#define HOST_DUBUG(...) printf(__VA_ARGS__)
+#define HOST_DEBUG(...) printf(__VA_ARGS__)
 #else
-#define HOST_DUBUG(...) VOID0
+#define HOST_DEBUG(...) VOID0
 #endif
 #else
-#define HOST_DUBUG(...) VOID0
+#define HOST_DEBUG(...) VOID0
 #endif
 
 UHS_EpInfo* UHS_USB_HOST_BASE::getEpInfoEntry(uint8_t addr, uint8_t ep) {
@@ -47,7 +54,7 @@ UHS_EpInfo* UHS_USB_HOST_BASE::getEpInfoEntry(uint8_t addr, uint8_t ep) {
 
                 for(uint8_t i = 0; i < p->epcount; i++) {
                         if((pep)->epAddr == ep) {
-                                HOST_DUBUG("ep entry for interface %d ep %d max packet size = %d\r\n", pep->bIface, ep, pep->maxPktSize);
+                                HOST_DEBUG("ep entry for interface %d ep %d max packet size = %d\r\n", pep->bIface, ep, pep->maxPktSize);
                                 return pep;
                         }
 
@@ -146,7 +153,7 @@ uint8_t UHS_USB_HOST_BASE::doSoftReset(uint8_t parent, uint8_t port, uint8_t add
                         retries++;
                         sof_delay(10);
                 } while(retries < 200);
-                HOST_DUBUG("%i retries.\r\n", retries);
+                HOST_DEBUG("%i retries.\r\n", retries);
         } else {
 #if DEBUG_PRINTF_EXTRA_HUGE
                 printf("\r\ndoSoftReset called with address == 0.\r\n");
@@ -214,7 +221,7 @@ uint8_t UHS_USB_HOST_BASE::doSoftReset(uint8_t parent, uint8_t port, uint8_t add
  */
 uint8_t UHS_USB_HOST_BASE::Configuring(uint8_t parent, uint8_t port, uint8_t speed) {
         //uint8_t bAddress = 0;
-        HOST_DUBUG("\r\n\r\n\r\nConfiguring: parent = %i, port = %i, speed = %i\r\n", parent, port, speed);
+        HOST_DEBUG("\r\n\r\n\r\nConfiguring: parent = %i, port = %i, speed = %i\r\n", parent, port, speed);
         uint8_t rcode = 0;
         uint8_t retries = 0;
         uint8_t numinf = 0;
@@ -253,7 +260,7 @@ uint8_t UHS_USB_HOST_BASE::Configuring(uint8_t parent, uint8_t port, uint8_t spe
                 sof_delay(200);
                 p = addrPool.GetUsbDevicePtr(0);
                 if(!p) {
-                        HOST_DUBUG("Configuring error: USB_ERROR_ADDRESS_NOT_FOUND_IN_POOL\r\n");
+                        HOST_DEBUG("Configuring error: USB_ERROR_ADDRESS_NOT_FOUND_IN_POOL\r\n");
                         return UHS_HOST_ERROR_NO_ADDRESS_IN_POOL;
                 }
 
@@ -268,7 +275,7 @@ uint8_t UHS_USB_HOST_BASE::Configuring(uint8_t parent, uint8_t port, uint8_t spe
 #endif
 again:
                 memset((void *)buf, 0, biggest);
-                HOST_DUBUG("\r\n\r\nConfiguring PktSize 0x%2.2x,  rcode: 0x%2.2x, retries %i,\r\n", p->epinfo[0][0].maxPktSize, rcode, retries);
+                HOST_DEBUG("\r\n\r\nConfiguring PktSize 0x%2.2x,  rcode: 0x%2.2x, retries %i,\r\n", p->epinfo[0][0].maxPktSize, rcode, retries);
                 rcode = getDevDescr(0, biggest, (uint8_t*)buf);
 #if UHS_DEVICE_WINDOWS_USB_SPEC_VIOLATION_DESCRIPTOR_DEVICE
                 if(rcode || udd->bMaxPacketSize0 < 8)
@@ -296,13 +303,13 @@ again:
                         } else if((rcode == UHS_HOST_ERROR_DMA || rcode == UHS_HOST_ERROR_MEM_LAT) && retries < 4) {
                                 if(p->epinfo[0][0].maxPktSize < 32) p->epinfo[0][0].maxPktSize = p->epinfo[0][0].maxPktSize << 1;
 #endif
-                                HOST_DUBUG("Configuring error: 0x%2.2x UHS_HOST_ERROR_DMA. Retry with maxPktSize: %i\r\n", rcode, p->epinfo[0][0].maxPktSize);
+                                HOST_DEBUG("Configuring error: 0x%2.2x UHS_HOST_ERROR_DMA. Retry with maxPktSize: %i\r\n", rcode, p->epinfo[0][0].maxPktSize);
                                 doSoftReset(parent, port, 0);
                                 retries++;
                                 sof_delay(200);
                                 goto again;
                         }
-                        HOST_DUBUG("Configuring error: 0x%2.2x Can't get USB_DEVICE_DESCRIPTOR\r\n", rcode);
+                        HOST_DEBUG("Configuring error: 0x%2.2x Can't get USB_DEVICE_DESCRIPTOR\r\n", rcode);
                         return rcode;
                 }
 
@@ -328,12 +335,12 @@ again:
 
                 if(rcode) {
                         addrPool.FreeAddress(ei.address);
-                        HOST_DUBUG("Configuring error: %2.2x Can't set USB INTERFACE ADDRESS\r\n", rcode);
+                        HOST_DEBUG("Configuring error: %2.2x Can't set USB INTERFACE ADDRESS\r\n", rcode);
                         return rcode;
                 }
 
                 { // the { } wrapper saves on stack.
-                        HOST_DUBUG("DevDescr 2nd poll, bMaxPacketSize0:%u\r\n", udd->bMaxPacketSize0);
+                        HOST_DEBUG("DevDescr 2nd poll, bMaxPacketSize0:%u\r\n", udd->bMaxPacketSize0);
                         UHS_EpInfo dev1ep;
                         dev1ep.maxPktSize = udd->bMaxPacketSize0;
                         dev1ep.epAddr = 0;
@@ -346,7 +353,7 @@ again:
                         sof_delay(10);
                         memset((void *)buf, 0, biggest);
                         rcode = getDevDescr(ei.address, 18, (uint8_t*)buf);
-                        if(rcode) HOST_DUBUG("getDevDescr err: 0x%x \r\n", rcode);
+                        if(rcode) HOST_DEBUG("getDevDescr err: 0x%x \r\n", rcode);
 
                         addrPool.FreeAddress(ei.address);
                         if(rcode && rcode != UHS_HOST_ERROR_DMA) {
@@ -394,29 +401,29 @@ again:
 
         if(rcode) {
                 addrPool.FreeAddress(ei.address);
-                HOST_DUBUG("Configuring error: %2.2x Can't set USB INTERFACE ADDRESS\r\n", rcode);
+                HOST_DEBUG("Configuring error: %2.2x Can't set USB INTERFACE ADDRESS\r\n", rcode);
                 return rcode;
         }
 
         if(configs < 1) {
-                HOST_DUBUG("No interfaces?!\r\n");
+                HOST_DEBUG("No interfaces?!\r\n");
                 addrPool.FreeAddress(ei.address);
                 // rcode = TestInterface(&ei);
                 // Not implemented (yet)
                 rcode = UHS_HOST_ERROR_DEVICE_NOT_SUPPORTED;
         } else {
-                HOST_DUBUG("configs: %i\r\n", configs);
+                HOST_DEBUG("configs: %i\r\n", configs);
                 for(uint8_t conf = 0; (!rcode) && (conf < configs); conf++) {
                         // read the config descriptor into a buffer.
                         rcode = getConfDescr(ei.address, sizeof (USB_CONFIGURATION_DESCRIPTOR), conf, buf);
                         if(rcode) {
-                                HOST_DUBUG("Configuring error: %2.2x Can't get USB_INTERFACE_DESCRIPTOR\r\n", rcode);
+                                HOST_DEBUG("Configuring error: %2.2x Can't get USB_INTERFACE_DESCRIPTOR\r\n", rcode);
                                 rcode = UHS_HOST_ERROR_FailGetConfDescr;
                                 continue;
                         }
                         ei.currentconfig = conf;
                         numinf = ucd->bNumInterfaces; // Does _not_ include alternates!
-                        HOST_DUBUG("CONFIGURATION: %i, bNumInterfaces %i, wTotalLength %i\r\n", conf, numinf, ucd->wTotalLength);
+                        HOST_DEBUG("CONFIGURATION: %i, bNumInterfaces %i, wTotalLength %i\r\n", conf, numinf, ucd->wTotalLength);
                         uint8_t success = 0;
                         uint16_t inf = 0;
                         uint8_t data[ei.bMaxPacketSize0];
@@ -431,20 +438,20 @@ again:
                         uint8_t offset;
                         rcode = initDescrStream(&ei, ucd, pep, data, &left, &read, &offset);
                         if(rcode) {
-                                HOST_DUBUG("Configuring error: %2.2x Can't get USB_INTERFACE_DESCRIPTOR stream.\r\n", rcode);
+                                HOST_DEBUG("Configuring error: %2.2x Can't get USB_INTERFACE_DESCRIPTOR stream.\r\n", rcode);
                                 break;
                         }
                         for(; (numinf) && (!rcode); inf++) {
                                 // iterate for each interface on this config
                                 rcode = getNextInterface(&ei, pep, data, &left, &read, &offset);
                                 if(rcode == UHS_HOST_ERROR_END_OF_STREAM) {
-                                        HOST_DUBUG("USB_INTERFACE END OF STREAM\r\n");
+                                        HOST_DEBUG("USB_INTERFACE END OF STREAM\r\n");
                                         ctrlReqClose(pep, UHS_bmREQ_GET_DESCR, left, ei.bMaxPacketSize0, data);
                                         rcode = 0;
                                         break;
                                 }
                                 if(rcode) {
-                                        HOST_DUBUG("Configuring error: %2.2x Can't close USB_INTERFACE_DESCRIPTOR stream.\r\n", rcode);
+                                        HOST_DEBUG("Configuring error: %2.2x Can't close USB_INTERFACE_DESCRIPTOR stream.\r\n", rcode);
                                         continue;
                                 }
                                 rcode = TestInterface(&ei);
@@ -466,7 +473,7 @@ again:
         if(!rcode) {
                 rcode = getConfDescr(ei.address, sizeof (USB_CONFIGURATION_DESCRIPTOR), bestconf, buf);
                 if(rcode) {
-                        HOST_DUBUG("Configuring error: %2.2x Can't get USB_INTERFACE_DESCRIPTOR\r\n", rcode);
+                        HOST_DEBUG("Configuring error: %2.2x Can't get USB_INTERFACE_DESCRIPTOR\r\n", rcode);
                         rcode = UHS_HOST_ERROR_FailGetConfDescr;
                 }
         }
@@ -474,9 +481,9 @@ again:
                 bestconf++;
                 ei.currentconfig = bestconf;
                 numinf = ucd->bNumInterfaces; // Does _not_ include alternates!
-                HOST_DUBUG("CONFIGURATION: %i, bNumInterfaces %i, wTotalLength %i\r\n", bestconf, numinf, ucd->wTotalLength);
+                HOST_DEBUG("CONFIGURATION: %i, bNumInterfaces %i, wTotalLength %i\r\n", bestconf, numinf, ucd->wTotalLength);
                 if(!rcode) {
-                        HOST_DUBUG("Best configuration is %i, enumerating interfaces.\r\n", bestconf);
+                        HOST_DEBUG("Best configuration is %i, enumerating interfaces.\r\n", bestconf);
                         uint16_t inf = 0;
                         uint8_t data[ei.bMaxPacketSize0];
                         UHS_EpInfo *pep;
@@ -490,7 +497,7 @@ again:
                                 uint8_t offset;
                                 rcode = initDescrStream(&ei, ucd, pep, data, &left, &read, &offset);
                                 if(rcode) {
-                                        HOST_DUBUG("Configuring error: %2.2x Can't get USB_INTERFACE_DESCRIPTOR stream.\r\n", rcode);
+                                        HOST_DEBUG("Configuring error: %2.2x Can't get USB_INTERFACE_DESCRIPTOR stream.\r\n", rcode);
                                 } else {
                                         for(; (numinf) && (!rcode); inf++) {
                                                 // iterate for each interface on this config
@@ -501,52 +508,52 @@ again:
                                                         break;
                                                 }
                                                 if(rcode) {
-                                                        HOST_DUBUG("Configuring error: %2.2x Can't close USB_INTERFACE_DESCRIPTOR stream.\r\n", rcode);
+                                                        HOST_DEBUG("Configuring error: %2.2x Can't close USB_INTERFACE_DESCRIPTOR stream.\r\n", rcode);
                                                         continue;
                                                 }
 
                                                 if(enumerateInterface(&ei) == UHS_HOST_MAX_INTERFACE_DRIVERS) {
-                                                        HOST_DUBUG("No interface driver for this interface.");
+                                                        HOST_DEBUG("No interface driver for this interface.");
                                                 } else {
-                                                        HOST_DUBUG("Interface Configured\r\n");
+                                                        HOST_DEBUG("Interface Configured\r\n");
                                                 }
                                         }
                                 }
                         }
                 } else {
-                        HOST_DUBUG("Configuring error: %2.2x Can't set USB_INTERFACE_CONFIG stream.\r\n", rcode);
+                        HOST_DEBUG("Configuring error: %2.2x Can't set USB_INTERFACE_CONFIG stream.\r\n", rcode);
                 }
         }
 
         if(!rcode) {
                 rcode = setConf(ei.address, bestconf);
                 if(rcode) {
-                        HOST_DUBUG("Configuring error: %2.2x Can't set Configuration.\r\n", rcode);
+                        HOST_DEBUG("Configuring error: %2.2x Can't set Configuration.\r\n", rcode);
                         addrPool.FreeAddress(ei.address);
                 } else {
                         for(devConfigIndex = 0; devConfigIndex < UHS_HOST_MAX_INTERFACE_DRIVERS; devConfigIndex++) {
-                                HOST_DUBUG("Driver %i ", devConfigIndex);
+                                HOST_DEBUG("Driver %i ", devConfigIndex);
                                 if(!devConfig[devConfigIndex]) {
-                                        HOST_DUBUG("no driver at this index.\r\n");
+                                        HOST_DEBUG("no driver at this index.\r\n");
                                         continue; // no driver
                                 }
-                                HOST_DUBUG("@ %2.2x ", devConfig[devConfigIndex]->bAddress);
+                                HOST_DEBUG("@ %2.2x ", devConfig[devConfigIndex]->bAddress);
                                 if(devConfig[devConfigIndex]->bAddress) {
                                         if(!devConfig[devConfigIndex]->bPollEnable) {
-                                                HOST_DUBUG("Initialize\r\n");
+                                                HOST_DEBUG("Initialize\r\n");
                                                 rcode = devConfig[devConfigIndex]->Finalize();
                                                 rcode = devConfig[devConfigIndex]->Start();
                                                 if(!rcode) {
-                                                        HOST_DUBUG("Total endpoints = (%i)%i\r\n", p->epcount, devConfig[devConfigIndex]->bNumEP);
+                                                        HOST_DEBUG("Total endpoints = (%i)%i\r\n", p->epcount, devConfig[devConfigIndex]->bNumEP);
                                                 } else {
                                                         break;
                                                 }
                                         } else {
-                                                HOST_DUBUG("Already initialized.\r\n");
+                                                HOST_DEBUG("Already initialized.\r\n");
                                                 continue; // consumed
                                         }
                                 } else {
-                                        HOST_DUBUG("Skipped\r\n");
+                                        HOST_DEBUG("Skipped\r\n");
                                 }
                         }
 #if 0 // defined(UHS_HID_LOADED)
@@ -666,10 +673,10 @@ uint8_t UHS_USB_HOST_BASE::setConf(uint8_t addr, uint8_t conf_value) {
 uint8_t UHS_USB_HOST_BASE::outTransfer(uint8_t addr, uint8_t ep, uint16_t nbytes, uint8_t* data) {
         UHS_EpInfo *pep = NULL;
         uint16_t nak_limit = 0;
-        HOST_DUBUG("outTransfer: addr: 0x%2.2x ep: 0x%2.2x nbytes: 0x%4.4x data: 0x%p\r\n", addr, ep, nbytes, data);
+        HOST_DEBUG("outTransfer: addr: 0x%2.2x ep: 0x%2.2x nbytes: 0x%4.4x data: 0x%p\r\n", addr, ep, nbytes, data);
 
         uint8_t rcode = SetAddress(addr, ep, &pep, nak_limit);
-        HOST_DUBUG("outTransfer: SetAddress 0x%2.2x\r\n", rcode);
+        HOST_DEBUG("outTransfer: SetAddress 0x%2.2x\r\n", rcode);
         if(!rcode)
                 rcode = OutTransfer(pep, nak_limit, nbytes, data);
         return rcode;
@@ -748,11 +755,11 @@ uint8_t UHS_USB_HOST_BASE::getNextInterface(ENUMERATION_INFO *ei, UHS_EpInfo *pe
                 if(rcode)
                         return rcode;
                 ty = data[*offset]; // bDescriptorType
-                HOST_DUBUG("bLength: %i ", remain);
-                HOST_DUBUG("bDescriptorType: %2.2x\r\n", ty);
+                HOST_DEBUG("bLength: %i ", remain);
+                HOST_DEBUG("bDescriptorType: %2.2x\r\n", ty);
                 remain--;
                 if(ty == USB_DESCRIPTOR_INTERFACE) {
-                        HOST_DUBUG("INTERFACE DESCRIPTOR FOUND\r\n");
+                        HOST_DEBUG("INTERFACE DESCRIPTOR FOUND\r\n");
                         ptr = (uint8_t *)(&(ei->interface.bInterfaceNumber));
                         for(int i = 0; i < 6; i++) {
                                 rcode = getone(pep, left, read, data, offset);
@@ -766,11 +773,11 @@ uint8_t UHS_USB_HOST_BASE::getNextInterface(ENUMERATION_INFO *ei, UHS_EpInfo *pe
                                 return rcode;
                         // Now at iInterface
                         // Get endpoints.
-                        HOST_DUBUG("Getting %i endpoints\r\n", ei->interface.numep);
+                        HOST_DEBUG("Getting %i endpoints\r\n", ei->interface.numep);
                         while(epc < ei->interface.numep) {
                                 rcode = getone(pep, left, read, data, offset);
                                 if(rcode) {
-                                        HOST_DUBUG("ENDPOINT DESCRIPTOR DIED WAY EARLY\r\n");
+                                        HOST_DEBUG("ENDPOINT DESCRIPTOR DIED WAY EARLY\r\n");
                                         return rcode;
                                 }
                                 remain = data[*offset]; // bLength
@@ -782,20 +789,20 @@ uint8_t UHS_USB_HOST_BASE::getNextInterface(ENUMERATION_INFO *ei, UHS_EpInfo *pe
                                 }
                                 rcode = getone(pep, left, read, data, offset);
                                 if(rcode) {
-                                        HOST_DUBUG("ENDPOINT DESCRIPTOR DIED EARLY\r\n");
+                                        HOST_DEBUG("ENDPOINT DESCRIPTOR DIED EARLY\r\n");
                                         return rcode;
                                 }
                                 ty = data[*offset]; // bDescriptorType
-                                HOST_DUBUG("bLength: %i ", remain);
-                                HOST_DUBUG("bDescriptorType: %2.2x\r\n", ty);
+                                HOST_DEBUG("bLength: %i ", remain);
+                                HOST_DEBUG("bDescriptorType: %2.2x\r\n", ty);
                                 remain -= 2;
                                 if(ty == USB_DESCRIPTOR_ENDPOINT) {
-                                        HOST_DUBUG("ENDPOINT DESCRIPTOR: %i\r\n", epc);
+                                        HOST_DEBUG("ENDPOINT DESCRIPTOR: %i\r\n", epc);
                                         ptr = (uint8_t *)(&(ei->interface.epInfo[epc].bEndpointAddress));
                                         for(unsigned int i = 0; i< sizeof (ENDPOINT_INFO); i++) {
                                                 rcode = getone(pep, left, read, data, offset);
                                                 if(rcode) {
-                                                        HOST_DUBUG("ENDPOINT DESCRIPTOR DIED LATE\r\n");
+                                                        HOST_DEBUG("ENDPOINT DESCRIPTOR DIED LATE\r\n");
                                                         return rcode;
                                                 }
                                                 *ptr = data[*offset];
@@ -803,11 +810,11 @@ uint8_t UHS_USB_HOST_BASE::getNextInterface(ENUMERATION_INFO *ei, UHS_EpInfo *pe
                                                 remain--;
                                         }
                                         epc++;
-                                        HOST_DUBUG("ENDPOINT DESCRIPTOR OK\r\n");
+                                        HOST_DEBUG("ENDPOINT DESCRIPTOR OK\r\n");
                                 }
                                 rcode = eat(pep, left, read, data, offset, &remain);
                                 if(rcode) {
-                                        HOST_DUBUG("ENDPOINT DESCRIPTOR DIED EATING\r\n");
+                                        HOST_DEBUG("ENDPOINT DESCRIPTOR DIED EATING\r\n");
                                         return rcode;
                                 }
                                 remain = 0;
@@ -818,7 +825,7 @@ uint8_t UHS_USB_HOST_BASE::getNextInterface(ENUMERATION_INFO *ei, UHS_EpInfo *pe
                         if(!ei->interface.numep && rcode) {
                                 return rcode;
                         }
-                        HOST_DUBUG("ENDPOINT DESCRIPTORS FILLED\r\n");
+                        HOST_DEBUG("ENDPOINT DESCRIPTORS FILLED\r\n");
                         return 0;
                 } else {
                         rcode = eat(pep, left, read, data, offset, &remain);
@@ -855,12 +862,12 @@ uint8_t UHS_USB_HOST_BASE::seekInterface(ENUMERATION_INFO *ei, uint16_t inf, USB
         rcode = getone(pep, &left, &read, data, &offset);
         if(rcode)
                 return rcode;
-        HOST_DUBUG("\r\nGetting interface: %i\r\n", inf);
+        HOST_DEBUG("\r\nGetting interface: %i\r\n", inf);
         inf++;
         while(cinf != inf && (left + read)) {
-                //HOST_DUBUG("getInterface: cinf: %i inf: %i left: %i read: %i offset: %i remain %i\r\n", cinf, inf, left, read, offset, remain);
+                //HOST_DEBUG("getInterface: cinf: %i inf: %i left: %i read: %i offset: %i remain %i\r\n", cinf, inf, left, read, offset, remain);
                 // Go past current descriptor
-                HOST_DUBUG("Skip: %i\r\n", remain);
+                HOST_DEBUG("Skip: %i\r\n", remain);
                 rcode = eat(pep, &left, &read, data, &offset, &remain);
                 if(rcode)
                         return rcode;
@@ -875,11 +882,11 @@ uint8_t UHS_USB_HOST_BASE::seekInterface(ENUMERATION_INFO *ei, uint16_t inf, USB
                 if(rcode)
                         return rcode;
                 ty = data[offset]; // bDescriptorType
-                HOST_DUBUG("bLength: %i ", remain);
-                HOST_DUBUG("bDescriptorType: %2.2x\r\n", ty);
+                HOST_DEBUG("bLength: %i ", remain);
+                HOST_DEBUG("bDescriptorType: %2.2x\r\n", ty);
                 remain--;
                 if(ty == USB_DESCRIPTOR_INTERFACE) {
-                        HOST_DUBUG("INTERFACE DESCRIPTOR: %i\r\n", cinf);
+                        HOST_DEBUG("INTERFACE DESCRIPTOR: %i\r\n", cinf);
                         cinf++;
                         if(cinf == inf) {
                                 // Get the interface descriptor information.
@@ -897,7 +904,7 @@ uint8_t UHS_USB_HOST_BASE::seekInterface(ENUMERATION_INFO *ei, uint16_t inf, USB
                                 // Now at iInterface
                                 remain = 0;
                                 // Get endpoints.
-                                HOST_DUBUG("Getting %i endpoints\r\n", ei->interface.numep);
+                                HOST_DEBUG("Getting %i endpoints\r\n", ei->interface.numep);
                                 while(epc < ei->interface.numep) {
                                         rcode = getone(pep, &left, &read, data, &offset);
                                         if(rcode)
@@ -913,11 +920,11 @@ uint8_t UHS_USB_HOST_BASE::seekInterface(ENUMERATION_INFO *ei, uint16_t inf, USB
                                         if(rcode)
                                                 return rcode;
                                         ty = data[offset]; // bDescriptorType
-                                        HOST_DUBUG("bLength: %i ", remain);
-                                        HOST_DUBUG("bDescriptorType: %2.2x\r\n", ty);
+                                        HOST_DEBUG("bLength: %i ", remain);
+                                        HOST_DEBUG("bDescriptorType: %2.2x\r\n", ty);
                                         remain--;
                                         if(ty == USB_DESCRIPTOR_ENDPOINT) {
-                                                HOST_DUBUG("ENDPOINT DESCRIPTOR: %i\r\n", epc);
+                                                HOST_DEBUG("ENDPOINT DESCRIPTOR: %i\r\n", epc);
                                                 ptr = (uint8_t *)(&(ei->interface.epInfo[epc].bEndpointAddress));
                                                 for(unsigned int i = 0; i< sizeof (ENDPOINT_INFO); i++) {
                                                         rcode = getone(pep, &left, &read, data, &offset);
@@ -966,7 +973,7 @@ uint8_t UHS_USB_HOST_BASE::getone(UHS_EpInfo *pep, uint16_t *left, uint16_t *rea
 
 uint8_t UHS_USB_HOST_BASE::eat(UHS_EpInfo *pep, uint16_t *left, uint16_t *read, uint8_t *dataptr, uint8_t *offset, uint16_t *yum) {
         uint8_t rcode = 0;
-        HOST_DUBUG("eating %i\r\n", *yum);
+        HOST_DEBUG("eating %i\r\n", *yum);
         while(*yum) {
                 *yum -= 1;
                 rcode = getone(pep, left, read, dataptr, offset);
@@ -982,7 +989,7 @@ uint8_t UHS_USB_HOST_BASE::ctrlReq(uint8_t addr, uint64_t Request, uint16_t nbyt
         //        Serial.println("");
         UHS_EpInfo *pep = ctrlReqOpen(addr, Request, dataptr);
         if(!pep) {
-                HOST_DUBUG("ctrlReq1: ERROR_NULL_EPINFO addr: %d\r\n", addr);
+                HOST_DEBUG("ctrlReq1: ERROR_NULL_EPINFO addr: %d\r\n", addr);
                 return UHS_HOST_ERROR_NULL_EPINFO;
         }
         uint8_t rt = (uint8_t)(Request & 0xFFU);
@@ -996,7 +1003,7 @@ uint8_t UHS_USB_HOST_BASE::ctrlReq(uint8_t addr, uint64_t Request, uint16_t nbyt
                         while(left) {
                                 // Bytes read into buffer
                                 uint16_t read = nbytes;
-                                HOST_DUBUG("ctrlReq2: left: %i, read:%i, nbytes %i\r\n", left, read, nbytes);
+                                HOST_DEBUG("ctrlReq2: left: %i, read:%i, nbytes %i\r\n", left, read, nbytes);
                                 rcode = ctrlReqRead(pep, &left, &read, nbytes, dataptr);
 
                                 if(rcode) {
@@ -1006,7 +1013,7 @@ uint8_t UHS_USB_HOST_BASE::ctrlReq(uint8_t addr, uint64_t Request, uint16_t nbyt
 
                                 // Should only be used for GET_DESCRIPTOR USB_DESCRIPTOR_DEVICE
                                 if(!addr && ((Request & (uint32_t)0xFF00FF00U) == (((uint32_t)USB_REQUEST_GET_DESCRIPTOR << 8) | ((uint32_t)USB_DESCRIPTOR_DEVICE << 24)))) {
-                                        HOST_DUBUG("ctrlReq3: acceptBuffer sz %i nbytes %i left %i\n\r", read, nbytes, left);
+                                        HOST_DEBUG("ctrlReq3: acceptBuffer sz %i nbytes %i left %i\n\r", read, nbytes, left);
                                         left = 0;
                                         break;
                                 }
@@ -1038,21 +1045,21 @@ uint8_t UHS_USB_HOST_BASE::TestInterface(ENUMERATION_INFO *ei) {
 
         uint8_t devConfigIndex;
         uint8_t rcode = 0;
-        HOST_DUBUG("TestInterface VID:%4.4x PID:%4.4x Class:%2.2x Subclass:%2.2x Protocol %2.2x\r\n", ei->vid, ei->pid, ei->klass, ei->subklass, ei->protocol);
-        HOST_DUBUG("Interface data: Class:%2.2x Subclass:%2.2x Protocol %2.2x, number of endpoints %i\r\n", ei->interface.klass, ei->interface.subklass, ei->interface.subklass, ei->interface.numep);
-        HOST_DUBUG("Parent: %2.2x, bAddress: %2.2x\r\n", ei->parent, ei->address);
+        HOST_DEBUG("TestInterface VID:%4.4x PID:%4.4x Class:%2.2x Subclass:%2.2x Protocol %2.2x\r\n", ei->vid, ei->pid, ei->klass, ei->subklass, ei->protocol);
+        HOST_DEBUG("Interface data: Class:%2.2x Subclass:%2.2x Protocol %2.2x, number of endpoints %i\r\n", ei->interface.klass, ei->interface.subklass, ei->interface.subklass, ei->interface.numep);
+        HOST_DEBUG("Parent: %2.2x, bAddress: %2.2x\r\n", ei->parent, ei->address);
         for(devConfigIndex = 0; devConfigIndex < UHS_HOST_MAX_INTERFACE_DRIVERS; devConfigIndex++) {
                 if(!devConfig[devConfigIndex]) {
-                        HOST_DUBUG("No driver at index %i\r\n", devConfigIndex);
+                        HOST_DEBUG("No driver at index %i\r\n", devConfigIndex);
                         continue; // no driver
                 }
                 if(devConfig[devConfigIndex]->bAddress) {
-                        HOST_DUBUG("Driver %i is already consumed @ %2.2x\r\n", devConfigIndex, devConfig[devConfigIndex]->bAddress);
+                        HOST_DEBUG("Driver %i is already consumed @ %2.2x\r\n", devConfigIndex, devConfig[devConfigIndex]->bAddress);
                         continue; // consumed
                 }
 
                 if(devConfig[devConfigIndex]->OKtoEnumerate(ei)) {
-                        HOST_DUBUG("Driver %i supports this interface\r\n", devConfigIndex);
+                        HOST_DEBUG("Driver %i supports this interface\r\n", devConfigIndex);
                         break;
                 }
         }
@@ -1066,15 +1073,15 @@ uint8_t UHS_USB_HOST_BASE::TestInterface(ENUMERATION_INFO *ei) {
                 }
 #endif
         }
-        if(!rcode) HOST_DUBUG("Driver %i can be used for this interface\r\n", devConfigIndex);
-        else HOST_DUBUG("No driver for this interface.\r\n");
+        if(!rcode) HOST_DEBUG("Driver %i can be used for this interface\r\n", devConfigIndex);
+        else HOST_DEBUG("No driver for this interface.\r\n");
         return rcode;
 };
 
 uint8_t UHS_USB_HOST_BASE::enumerateInterface(ENUMERATION_INFO *ei) {
         uint8_t devConfigIndex;
 
-        HOST_DUBUG("AttemptConfig: parent = %i, port = %i\r\n", ei->parent, ei->port);
+        HOST_DEBUG("AttemptConfig: parent = %i, port = %i\r\n", ei->parent, ei->port);
 
 #if 0 // defined(UHS_HID_LOADED)
         // Check HID here, if it is, then lie
@@ -1085,16 +1092,16 @@ uint8_t UHS_USB_HOST_BASE::enumerateInterface(ENUMERATION_INFO *ei) {
 #endif
                 for(devConfigIndex = 0; devConfigIndex < UHS_HOST_MAX_INTERFACE_DRIVERS; devConfigIndex++) {
                         if(!devConfig[devConfigIndex]) {
-                                HOST_DUBUG("No driver at index %i\r\n", devConfigIndex);
+                                HOST_DEBUG("No driver at index %i\r\n", devConfigIndex);
                                 continue; // no driver
                         }
                         if(devConfig[devConfigIndex]->bAddress) {
-                                HOST_DUBUG("Driver %i is already consumed @ %2.2x\r\n", devConfigIndex, devConfig[devConfigIndex]->bAddress);
+                                HOST_DEBUG("Driver %i is already consumed @ %2.2x\r\n", devConfigIndex, devConfig[devConfigIndex]->bAddress);
                                 continue; // consumed
                         }
 
                         if(devConfig[devConfigIndex]->OKtoEnumerate(ei)) {
-                                HOST_DUBUG("Driver %i supports this interface\r\n", devConfigIndex);
+                                HOST_DEBUG("Driver %i supports this interface\r\n", devConfigIndex);
                                 if(!devConfig[devConfigIndex]->SetInterface(ei)) break;
                                 else devConfigIndex = UHS_HOST_MAX_INTERFACE_DRIVERS;
                         }

--- a/libraries/UHS_host/UHS_macros.h
+++ b/libraries/UHS_host/UHS_macros.h
@@ -2,12 +2,19 @@
    and
 Copyright (C) 2011 Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Contact information
 -------------------

--- a/libraries/UHS_host/UHS_message.h
+++ b/libraries/UHS_host/UHS_message.h
@@ -2,12 +2,19 @@
    and
 Copyright (C) 2011 Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Contact information
 -------------------

--- a/libraries/UHS_host/UHS_printf_HELPER.h
+++ b/libraries/UHS_host/UHS_printf_HELPER.h
@@ -2,12 +2,19 @@
    and
 Copyright (C) 2011 Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Contact information
 -------------------

--- a/libraries/UHS_host/UHS_printhex.h
+++ b/libraries/UHS_host/UHS_printhex.h
@@ -2,12 +2,19 @@
    and
 Copyright (C) 2011 Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Contact information
 -------------------

--- a/libraries/UHS_host/UHS_settings.h
+++ b/libraries/UHS_host/UHS_settings.h
@@ -2,12 +2,19 @@
    and
 Copyright (C) 2011 Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Contact information
 -------------------

--- a/libraries/UHS_host/UHS_usb_ch9.h
+++ b/libraries/UHS_host/UHS_usb_ch9.h
@@ -2,12 +2,19 @@
    and
 Copyright (C) 2011 Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Contact information
 -------------------

--- a/libraries/UHS_host/UHS_usbhost.h
+++ b/libraries/UHS_host/UHS_usbhost.h
@@ -2,12 +2,19 @@
    and
 Copyright (C) 2011 Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Contact information
 -------------------

--- a/libraries/UHS_host/UHS_util_INLINE.h
+++ b/libraries/UHS_host/UHS_util_INLINE.h
@@ -2,12 +2,19 @@
    and
 Copyright (C) 2011 Circuits At Home, LTD. All rights reserved.
 
-This software may be distributed and modified under the terms of the GNU
-General Public License version 2 (GPL2) as published by the Free Software
-Foundation and appearing in the file GPL2.TXT included in the packaging of
-this file. Please note that GPL2 Section 2[b] requires that all works based
-on this software must also be made publicly available under the terms of
-the GPL2 ("Copyleft").
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Contact information
 -------------------

--- a/libraries/UHS_host/USB_HOST_SHIELD/USB_HOST_SHIELD.h
+++ b/libraries/UHS_host/USB_HOST_SHIELD/USB_HOST_SHIELD.h
@@ -136,7 +136,7 @@ e-mail   :  support@circuitsathome.com
 #elif defined(ARDUINO_spresense_ast)
 #define UHS_MAX3421E_SS_ 21
 #define UHS_MAX3421E_INT_ 20
-#define SPIklass SPI5
+#define SPIclass SPI5
 //#define UHS_MAX3421E_SPD 100000
 #elif defined(CORE_TEENSY) && (defined(__AVR_AT90USB646__) || defined(__AVR_AT90USB1286__))
 
@@ -469,8 +469,8 @@ public:
 
 
 };
-#if !defined(SPIklass)
-#define SPIklass SPI
+#if !defined(SPIclass)
+#define SPIclass SPI
 #endif
 #if !defined(USB_HOST_SHIELD_LOADED)
 #include "USB_HOST_SHIELD_INLINE.h"

--- a/libraries/UHS_host/USB_HOST_SHIELD/USB_HOST_SHIELD_INLINE.h
+++ b/libraries/UHS_host/USB_HOST_SHIELD/USB_HOST_SHIELD_INLINE.h
@@ -50,13 +50,13 @@ static void UHS_NI call_ISRodd(void) {
 
 /* write single byte into MAX3421e register */
 void UHS_NI MAX3421E_HOST::regWr(uint8_t reg, uint8_t data) {
-        SPIklass.beginTransaction(MAX3421E_SPI_Settings);
+        SPIclass.beginTransaction(MAX3421E_SPI_Settings);
 
         UHS_PIN_WRITE(ss_pin, LOW);
-        SPIklass.transfer(reg | 0x02);
-        SPIklass.transfer(data);
+        SPIclass.transfer(reg | 0x02);
+        SPIclass.transfer(data);
         UHS_PIN_WRITE(ss_pin, HIGH);
-        SPIklass.endTransaction();
+        SPIclass.endTransaction();
 }
 
 
@@ -64,19 +64,19 @@ void UHS_NI MAX3421E_HOST::regWr(uint8_t reg, uint8_t data) {
 
 /* returns a pointer to memory position after last written */
 uint8_t* UHS_NI MAX3421E_HOST::bytesWr(uint8_t reg, uint8_t nbytes, uint8_t* data_p) {
-        SPIklass.beginTransaction(MAX3421E_SPI_Settings);
+        SPIclass.beginTransaction(MAX3421E_SPI_Settings);
         UHS_PIN_WRITE(ss_pin, LOW);
-        SPIklass.transfer(reg | 0x02);
+        SPIclass.transfer(reg | 0x02);
         //printf("%2.2x :", reg);
 
         while(nbytes) {
-                SPIklass.transfer(*data_p);
+                SPIclass.transfer(*data_p);
                 //printf("%2.2x ", *data_p);
                 nbytes--;
                 data_p++; // advance data pointer
         }
         UHS_PIN_WRITE(ss_pin, HIGH);
-        SPIklass.endTransaction();
+        SPIclass.endTransaction();
         //printf("\r\n");
         return (data_p);
 }
@@ -93,27 +93,27 @@ void UHS_NI MAX3421E_HOST::gpioWr(uint8_t data) {
 
 /* single host register read    */
 uint8_t UHS_NI MAX3421E_HOST::regRd(uint8_t reg) {
-        SPIklass.beginTransaction(MAX3421E_SPI_Settings);
+        SPIclass.beginTransaction(MAX3421E_SPI_Settings);
         UHS_PIN_WRITE(ss_pin, LOW);
-        SPIklass.transfer(reg);
-        uint8_t rv = SPIklass.transfer(0);
+        SPIclass.transfer(reg);
+        uint8_t rv = SPIclass.transfer(0);
         UHS_PIN_WRITE(ss_pin, HIGH);
-        SPIklass.endTransaction();
+        SPIclass.endTransaction();
         return (rv);
 }
 /* multiple-byte register read  */
 
 /* returns a pointer to a memory position after last read   */
 uint8_t* UHS_NI MAX3421E_HOST::bytesRd(uint8_t reg, uint8_t nbytes, uint8_t* data_p) {
-        SPIklass.beginTransaction(MAX3421E_SPI_Settings);
+        SPIclass.beginTransaction(MAX3421E_SPI_Settings);
         UHS_PIN_WRITE(ss_pin, LOW);
-        SPIklass.transfer(reg);
+        SPIclass.transfer(reg);
         while(nbytes) {
-                *data_p++ = SPIklass.transfer(0);
+                *data_p++ = SPIclass.transfer(0);
                 nbytes--;
         }
         UHS_PIN_WRITE(ss_pin, HIGH);
-        SPIklass.endTransaction();
+        SPIclass.endTransaction();
         return ( data_p);
 }
 
@@ -266,7 +266,7 @@ int16_t UHS_NI MAX3421E_HOST::Init(int16_t mseconds) {
                 PORTJ |= 0x04; // HIGH
         }
 #endif
-        SPIklass.begin();
+        SPIclass.begin();
 #ifdef ARDUINO_AVR_ADK
         if(irq_pin == 54) {
                 DDRE &= ~0x20; // input
@@ -296,16 +296,16 @@ int16_t UHS_NI MAX3421E_HOST::Init(int16_t mseconds) {
 #endif
                         return (-2);
         }
-        SPIklass.usingInterrupt(intr);
+        SPIclass.usingInterrupt(intr);
 #else
-        SPIklass.usingInterrupt(255);
+        SPIclass.usingInterrupt(255);
 #endif
 #if !defined(NO_AUTO_SPEED)
         // test to get to reset acceptance.
         uint32_t spd = UHS_MAX3421E_SPD;
 again:
         MAX3421E_SPI_Settings = SPISettings(spd, MSBFIRST, SPI_MODE0);
-        /* MAX3421E - full-duplex SPIklass, interrupt kind, vbus off */
+        /* MAX3421E - full-duplex SPIclass, interrupt kind, vbus off */
         regWr(rPINCTL, (bmFDUPSPI | bmIRQ_SENSE | GPX_VBDET));
         if(reset() == 0) {
                 MAX_HOST_DEBUG("Fail SPI speed %lu\r\n", spd);

--- a/libraries/UHS_host/USB_HOST_SHIELD/examples/board_qc/board_qc.ino
+++ b/libraries/UHS_host/USB_HOST_SHIELD/examples/board_qc/board_qc.ino
@@ -69,7 +69,7 @@ void setup() {
         // Manually initialize ahead of time
         Init_dyn_SWI();
         UHS_printf_HELPER_init();
-        SPIklass.begin();
+        SPIclass.begin();
 
         UHS_Usb.ss_pin = UHS_MAX3421E_SS;
         UHS_Usb.irq_pin = UHS_MAX3421E_INT;

--- a/libraries/dyn_SWI/SWI_INLINE.h
+++ b/libraries/dyn_SWI/SWI_INLINE.h
@@ -7,6 +7,19 @@
  * This is the actual library.
  * There are no 'c' or 'cpp' files.
  *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 #ifdef DYN_SWI_H
 #ifndef SWI_INLINE_H

--- a/libraries/dyn_SWI/dyn_SWI.h
+++ b/libraries/dyn_SWI/dyn_SWI.h
@@ -3,6 +3,20 @@
  * Author: xxxajk@gmail.com
  *
  * Created on December 5, 2014, 9:12 AM
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
 #ifndef DYN_SWI_H


### PR DESCRIPTION
This change would allow this code to be used in Marlin, which is GPLv3.

Currently [some](https://github.com/felis/UHS30/blob/master/libraries/UHS_FS/FAT/FAT.cpp) [of](https://github.com/felis/UHS30/blob/master/libraries/UHS_FS/FAT/FAT.h) [the files](https://github.com/felis/UHS30/blob/master/libraries/UHS_FS/PCpartition/PCPartition.h) in UHS are already marked GPLv3, so technically this change is needed for the whole to be compatible with itself...